### PR TITLE
[FIX] Python minimum requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = { file = "LICENSE" }
 authors = [
     { name = "AaronKable", email = "aaronkable@gmail.com" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Environment :: Web Environment",
     "Framework :: Celery",
@@ -27,8 +27,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
The code in api/schema.py , in particular https://github.com/Solar-Helix-Independent-Transport/allianceauth-corp-tools/blob/master/corptools/api/schema.py#L222 , breaks on python <3.10 . Since the code is tested starting from python 3.10, it has not been caught.
Fail : https://github.com/Maestro-Zacht/aa-charlink/actions/runs/13218069502/job/36899819294
Success: https://github.com/Maestro-Zacht/aa-charlink/actions/runs/13218069502/job/36899819552