### PR TITLE
[FIX] Remove tasks with old calls before updating to the new ones

### DIFF
--- a/corptools/management/commands/ct_setup.py
+++ b/corptools/management/commands/ct_setup.py
@@ -40,8 +40,13 @@ class Command(BaseCommand):
             timezone=schedule_b.timezone,
         )
 
+        try:
+            PeriodicTask.objects.get(task='corptools.tasks.update_subset_of_characters').delete()
+        except PeriodicTask.DoesNotExist:
+            pass
+
         PeriodicTask.objects.update_or_create(
-            task='corptools.tasks.update_subset_of_characters',
+            task='corptools.tasks.character.update_subset_of_characters',
             defaults={
                 'crontab': schedule_char,
                 'name': 'Character Audit Rolling Update',
@@ -49,8 +54,13 @@ class Command(BaseCommand):
             }
         )
 
+        try:
+            PeriodicTask.objects.get(task='corptools.tasks.update_all_corps').delete()
+        except PeriodicTask.DoesNotExist:
+            pass
+
         PeriodicTask.objects.update_or_create(
-            task='corptools.tasks.update_all_corps',
+            task='corptools.tasks.corporation.update_all_corps',
             defaults={
                 'crontab': schedule_corp,
                 'name': 'Corporation Audit Update',

--- a/corptools/views.py
+++ b/corptools/views.py
@@ -209,9 +209,9 @@ def admin(request):
     corpations = CorporationAudit.objects.all().count()
 
     char_tasks = PeriodicTask.objects.filter(
-        task='corptools.tasks.update_subset_of_characters', enabled=True).count()
+        task='corptools.tasks.character.update_subset_of_characters', enabled=True).count()
     corp_tasks = PeriodicTask.objects.filter(
-        task='corptools.tasks.update_all_corps', enabled=True).count()
+        task='corptools.tasks.corporation.update_all_corps', enabled=True).count()
 
     context = {
         "names": names,
@@ -293,8 +293,13 @@ def admin_create_tasks(request):
         timezone=schedule_b.timezone,
     )
 
+    try:
+        PeriodicTask.objects.get(task='corptools.tasks.update_subset_of_characters').delete()
+    except PeriodicTask.DoesNotExist:
+        pass
+
     PeriodicTask.objects.update_or_create(
-        task='corptools.tasks.update_subset_of_characters',
+        task='corptools.tasks.character.update_subset_of_characters',
         defaults={
             'crontab': schedule_char,
             'name': 'Character Audit Rolling Update',
@@ -302,8 +307,13 @@ def admin_create_tasks(request):
         }
     )
 
+    try:
+        PeriodicTask.objects.get(task='corptools.tasks.update_all_corps').delete()
+    except PeriodicTask.DoesNotExist:
+        pass
+
     PeriodicTask.objects.update_or_create(
-        task='corptools.tasks.update_all_corps',
+        task='corptools.tasks.corporation.update_all_corps',
         defaults={
             'crontab': schedule_corp,
             'name': 'Corporation Audit Update',


### PR DESCRIPTION
Fixes #192 

Important:
After updating to the new release, AA instance maintainers need to either:
- Go to `/audit/admin/` and click the "Create or update task" Button
- Run the `python manage.py ct_setup` command again