### PR TITLE
Admin template fixes

### DIFF
--- a/corptools/templates/corptools/admin.html
+++ b/corptools/templates/corptools/admin.html
@@ -1,6 +1,6 @@
 {% extends 'allianceauth/base-bs5.html' %}
 {% load i18n %}
-{% block page_title %}{{page_title}}{% endblock %}
+{% block page_title %}{% translate "Corptools Admin" %}{% endblock %}
 
 {% block header_nav_collapse_left %}
     {% include 'corptools/top_menu.html' %}

--- a/corptools/templates/corptools/admin.html
+++ b/corptools/templates/corptools/admin.html
@@ -13,44 +13,44 @@
         <!-- <div class="card m-2 flex-grow-1" style="min-width: 350px;"> -->
             <div class="card-body">
                 <h5 class="card-title text-center">
-                    Manual Task Run
+                    {% translate "Manual Task Run" %}
                 </h5>
                 <hr>
                 {% csrf_token %}
                 <div class="form-check">
                     <input type="checkbox" name="run_clear_etag" class="form-check-input" id="run_clear_etag">
                     <label class="form-check-label" for="run_clear_etag">{% translate "Clear all cached Etags" %}</label>
-                    <p class="figure-caption">Wipe all the etags from cache to force new data pulls</p>
+                    <p class="figure-caption">{% translate "Wipe all the etags from cache to force new data pulls" %}</p>
                 </div>
 
                 <div class="form-check">
                     <input type="checkbox" name="run_universe" class="form-check-input" id="run_universe">
                     <label class="form-check-label" for="run_universe">{% translate "Update EvE Map Data" %}</label>
-                    <p class="figure-caption">Force a full map update from ESI</p>
+                    <p class="figure-caption">{% translate "Force a full map update from ESI" %}</p>
                 </div>
 
                 <div class="form-check">
                     <input type="checkbox" name="run_locations" class="form-check-input" id="run_locations">
                     <label class="form-check-label" for="run_locations">{% translate "Force update all Citadel Locations" %}</label>
-                    <p class="figure-caption">Attempt to update all Citadel names from ESI</p>
+                    <p class="figure-caption">{% translate "Attempt to update all Citadel names from ESI" %}</p>
                 </div>
 
                 <div class="form-check">
                     <input type="checkbox" name="run_update_all" class="form-check-input" id="run_update_all">
                     <label class="form-check-label" for="run_update_all">{% translate "Force all character updates" %}</label>
-                    <p class="figure-caption">Force updates to ALL Character Audits</p>
+                    <p class="figure-caption">{% translate "Force updates to ALL Character Audits" %}</p>
                 </div>
 
                 <div class="form-check">
                     <input type="checkbox" name="run_corp_updates" class="form-check-input" id="run_corp_updates">
                     <label class="form-check-label" for="run_corp_updates">{% translate "Force all corp updates" %}</label>
-                    <p class="figure-caption">Force updates to ALL Corporation Audits</p>
+                    <p class="figure-caption">{% translate "Force updates to ALL Corporation Audits" %}</p>
                 </div>
 
                 <div class="form-check">
                     <input type="checkbox" name="run_update_eve_models" class="form-check-input" id="run_update_eve_models">
                     <label class="form-check-label" for="run_update_eve_models">{% translate "Update Eve Entirty Models" %}</label>
-                    <p class="figure-caption">Force updates to ALL Eve Entity Names</p>
+                    <p class="figure-caption">{% translate "Force updates to ALL Eve Entity Names" %}</p>
                 </div>
             </div>
 
@@ -62,25 +62,25 @@
     <div class="card m-2 flex-grow-1">
         <div class="card-body">
             <h5 class="card-title text-center">
-                Corptools Module Configuration
+                {% translate "Corptools Module Configuration" %}
             </h5>
             <div>
                 <table class="table">
                     <thead>
                       <tr>
-                        <th>Module</th>
-                        <th>Enabled</th>
-                        <th>Include in Active</th>
-                        <th>Temp Disabled</th>
+                        <th>{% translate "Module" %}</th>
+                        <th>{% translate "Enabled" %}</th>
+                        <th>{% translate "Include in Active" %}</th>
+                        <th>{% translate "Temp Disabled" %}</th>
                       </tr>
                     </thead>
                     <tbody>
                         <tr>
-                            <td>Assets
+                            <td>{% translate "Assets" %}
                                 {% if ct_config.disable_verification_assets %}
-                                    <span class="text-danger">( Validation Disabled )</span>
+                                    <span class="text-danger">{% translate "(Validation Disabled)" %}</span>
                                 {% else %}
-                                    <span class="text-success">( Validation Enabled )</span>
+                                    <span class="text-success">{% translate "(Validation Enabled)" %}</span>
                                 {% endif %}
                             </td>
                             <td class="text-center">
@@ -106,7 +106,7 @@
                             </td>
                         </tr>
                         <!-- <tr>
-                            <td>Standings</td>
+                            <td>{% translate "Standings" %}</td>
                             <td class="text-center">
                                 {% if app_settings.CT_CHAR_STANDINGS_MODULE %}
                                     <i class="fas fa-check-circle text-success"></i>
@@ -130,7 +130,7 @@
                             </td>
                         </tr> -->
                         <tr>
-                            <td>Contacts</td>
+                            <td>{% translate "Contacts" %}</td>
                             <td class="text-center">
                                 {% if app_settings.CT_CHAR_CONTACTS_MODULE %}
                                     <i class="fas fa-check-circle text-success"></i>
@@ -154,11 +154,11 @@
                             </td>
                         </tr>
                         <tr>
-                            <td>Notifications
+                            <td>{% translate "Notifications" %}
                                 {% if ct_config.disable_verification_notifications %}
-                                    <span class="text-danger">( Validation Disabled )</span>
+                                    <span class="text-danger">{% translate "(Validation Disabled)" %}</span>
                                 {% else %}
-                                    <span class="text-success">( Validation Enabled )</span>
+                                    <span class="text-success">{% translate "(Validation Enabled)" %}</span>
                                 {% endif %}
                             </td>
                             <td class="text-center">
@@ -184,7 +184,7 @@
                             </td>
                         </tr>
                         <tr>
-                            <td>Roles</td>
+                            <td>{% translate "Roles" %}</td>
                             <td class="text-center">
                                 {% if app_settings.CT_CHAR_ROLES_MODULE %}
                                     <i class="fas fa-check-circle text-success"></i>
@@ -208,7 +208,7 @@
                             </td>
                         </tr>
                         <tr>
-                            <td>Industry</td>
+                            <td>{% translate "Industry" %}</td>
                             <td class="text-center">
                                 {% if app_settings.CT_CHAR_INDUSTRY_MODULE %}
                                     <i class="fas fa-check-circle text-success"></i>
@@ -232,7 +232,7 @@
                             </td>
                         </tr>
                         <tr>
-                            <td>Mining</td>
+                            <td>{% translate "Mining" %}</td>
                             <td class="text-center">
                                 {% if app_settings.CT_CHAR_MINING_MODULE %}
                                     <i class="fas fa-check-circle text-success"></i>
@@ -256,7 +256,7 @@
                             </td>
                         </tr>
                         <tr>
-                            <td>Wallets/Markets/Contracts</td>
+                            <td>{% translate "Wallets/Markets/Contracts" %}</td>
                             <td class="text-center">
                                 {% if app_settings.CT_CHAR_WALLET_MODULE %}
                                     <i class="fas fa-check-circle text-success"></i>
@@ -280,7 +280,7 @@
                             </td>
                         </tr>
                         <tr>
-                            <td>Skills</td>
+                            <td>{% translate "Skills" %}</td>
                             <td class="text-center">
                                 {% if app_settings.CT_CHAR_SKILLS_MODULE %}
                                     <i class="fas fa-check-circle text-success"></i>
@@ -304,7 +304,7 @@
                             </td>
                         </tr>
                         <tr>
-                            <td>Clones</td>
+                            <td>{% translate "Clones" %}</td>
                             <td class="text-center">
                                 {% if app_settings.CT_CHAR_CLONES_MODULE %}
                                     <i class="fas fa-check-circle text-success"></i>
@@ -328,7 +328,7 @@
                             </td>
                         </tr>
                         <tr>
-                            <td>Mail</td>
+                            <td>{% translate "Mail" %}</td>
                             <td class="text-center">
                                 {% if app_settings.CT_CHAR_MAIL_MODULE %}
                                     <i class="fas fa-check-circle text-success"></i>
@@ -352,7 +352,7 @@
                             </td>
                         </tr>
                         <tr>
-                            <td>Loyalty Points</td>
+                            <td>{% translate "Loyalty Points" %}</td>
                             <td class="text-center">
                                 {% if app_settings.CT_CHAR_LOYALTYPOINTS_MODULE %}
                                     <i class="fas fa-check-circle text-success"></i>
@@ -383,7 +383,7 @@
     <div class="card m-2 flex-grow-1" style="min-width: 350px;">
         <div class="card-body">
             <h5 class="card-title text-center">
-                Eve Models
+                {% translate "Eve Models" %}
             </h5>
             <hr>
             <div>
@@ -437,7 +437,7 @@
     <div class="card m-2 flex-grow-1" style="min-width: 350px;">
         <div class="card-body">
             <h5 class="card-title text-center">
-                Eve Universe Models
+                {% translate "Eve Universe Models" %}
             </h5>
             <hr>
             <div>
@@ -479,7 +479,7 @@
     <div class="card m-2 flex-grow-1" style="min-width: 350px;">
         <div class="card-body">
             <h5 class="card-title text-center">
-                Audit Models
+                {% translate "Audit Models" %}
             </h5>
             <hr>
             <div>
@@ -505,7 +505,7 @@
                 </table>
             </div>
             <h5 class="card-title text-center">
-                Audit Tasks
+                {% translate "Audit Tasks" %}
             </h5>
             <hr>
             <table class="table">

--- a/corptools/templates/corptools/admin.html
+++ b/corptools/templates/corptools/admin.html
@@ -17,40 +17,40 @@
                 </h5>
                 <hr>
                 {% csrf_token %}
-                <div class="form-check">
+                <div class="form-check mb-3">
                     <input type="checkbox" name="run_clear_etag" class="form-check-input" id="run_clear_etag">
                     <label class="form-check-label" for="run_clear_etag">{% translate "Clear all cached Etags" %}</label>
-                    <p class="figure-caption">{% translate "Wipe all the etags from cache to force new data pulls" %}</p>
+                    <div class="form-text">{% translate "Wipe all the etags from cache to force new data pulls" %}</div>
                 </div>
 
-                <div class="form-check">
+                <div class="form-check mb-3">
                     <input type="checkbox" name="run_universe" class="form-check-input" id="run_universe">
                     <label class="form-check-label" for="run_universe">{% translate "Update EvE Map Data" %}</label>
-                    <p class="figure-caption">{% translate "Force a full map update from ESI" %}</p>
+                    <div class="form-text">{% translate "Force a full map update from ESI" %}</div>
                 </div>
 
-                <div class="form-check">
+                <div class="form-check mb-3">
                     <input type="checkbox" name="run_locations" class="form-check-input" id="run_locations">
                     <label class="form-check-label" for="run_locations">{% translate "Force update all Citadel Locations" %}</label>
-                    <p class="figure-caption">{% translate "Attempt to update all Citadel names from ESI" %}</p>
+                    <div class="form-text">{% translate "Attempt to update all Citadel names from ESI" %}</div>
                 </div>
 
-                <div class="form-check">
+                <div class="form-check mb-3">
                     <input type="checkbox" name="run_update_all" class="form-check-input" id="run_update_all">
                     <label class="form-check-label" for="run_update_all">{% translate "Force all character updates" %}</label>
-                    <p class="figure-caption">{% translate "Force updates to ALL Character Audits" %}</p>
+                    <div class="form-text">{% translate "Force updates to ALL Character Audits" %}</div>
                 </div>
 
-                <div class="form-check">
+                <div class="form-check mb-3">
                     <input type="checkbox" name="run_corp_updates" class="form-check-input" id="run_corp_updates">
                     <label class="form-check-label" for="run_corp_updates">{% translate "Force all corp updates" %}</label>
-                    <p class="figure-caption">{% translate "Force updates to ALL Corporation Audits" %}</p>
+                    <div class="form-text">{% translate "Force updates to ALL Corporation Audits" %}</div>
                 </div>
 
-                <div class="form-check">
+                <div class="form-check mb-3">
                     <input type="checkbox" name="run_update_eve_models" class="form-check-input" id="run_update_eve_models">
                     <label class="form-check-label" for="run_update_eve_models">{% translate "Update Eve Entirty Models" %}</label>
-                    <p class="figure-caption">{% translate "Force updates to ALL Eve Entity Names" %}</p>
+                    <div class="form-text">{% translate "Force updates to ALL Eve Entity Names" %}</div>
                 </div>
             </div>
 
@@ -535,12 +535,13 @@
             <hr>
             <div>
                 {% csrf_token %}
-                <div class="form-group">
+                <div class="form-group mb-3">
                     <label for="name">{% translate "Skill List Description" %}</label>
                     <input type="text" class="form-control" name="name" placeholder="Enter Description">
-                    <small id="nameHelp" class="form-text text-muted">{% translate "This will show as the name of the Skill List" %}.</small>
+                    <div id="nameHelp" class="form-text">{% translate "This will show as the name of the Skill List" %}.</div>
                 </div>
-                <div class="form-group">
+
+                <div class="form-group mb-3">
                     <div class="input-group">
                         <span class='form-control' id="upload-file-info"></span>
                         <span class="input-group-btn">
@@ -550,7 +551,7 @@
                             </label>
                         </span>
                     </div>
-                    <p id="descriptionHelp" class="form-text text-muted">{% translate "PYFA XML Skills required list" %}.</p>
+                    <div id="descriptionHelp" class="form-text">{% translate "PYFA XML Skills required list" %}.</div>
                 </div>
             </div>
         </div>

--- a/corptools/templates/corptools/admin.html
+++ b/corptools/templates/corptools/admin.html
@@ -20,39 +20,40 @@
                 <div class="form-check">
                     <input type="checkbox" name="run_clear_etag" class="form-check-input" id="run_clear_etag">
                     <label class="form-check-label" for="run_clear_etag">{% translate "Clear all cached Etags" %}</label>
+                    <p class="figure-caption">Wipe all the etags from cache to force new data pulls</p>
                 </div>
-                <figcaption class="figure-caption">Wipe all the etags from cache to force new data pulls</figcaption>
-                <br>
+
                 <div class="form-check">
                     <input type="checkbox" name="run_universe" class="form-check-input" id="run_universe">
                     <label class="form-check-label" for="run_universe">{% translate "Update EvE Map Data" %}</label>
+                    <p class="figure-caption">Force a full map update from ESI</p>
                 </div>
-                <figcaption class="figure-caption">Force a full map update from ESI</figcaption>
-                <br>
+
                 <div class="form-check">
                     <input type="checkbox" name="run_locations" class="form-check-input" id="run_locations">
                     <label class="form-check-label" for="run_locations">{% translate "Force update all Citadel Locations" %}</label>
+                    <p class="figure-caption">Attempt to update all Citadel names from ESI</p>
                 </div>
-                <figcaption class="figure-caption">Attempt to update all Citadel names from ESI</figcaption>
-                <br>
+
                 <div class="form-check">
                     <input type="checkbox" name="run_update_all" class="form-check-input" id="run_update_all">
                     <label class="form-check-label" for="run_update_all">{% translate "Force all character updates" %}</label>
+                    <p class="figure-caption">Force updates to ALL Character Audits</p>
                 </div>
-                <figcaption class="figure-caption">Force updates to ALL Character Audits</figcaption>
-                <br>
+
                 <div class="form-check">
                     <input type="checkbox" name="run_corp_updates" class="form-check-input" id="run_corp_updates">
                     <label class="form-check-label" for="run_corp_updates">{% translate "Force all corp updates" %}</label>
+                    <p class="figure-caption">Force updates to ALL Corporation Audits</p>
                 </div>
-                <figcaption class="figure-caption">Force updates to ALL Corporation Audits</figcaption>
-                <br>
+
                 <div class="form-check">
                     <input type="checkbox" name="run_update_eve_models" class="form-check-input" id="run_update_eve_models">
                     <label class="form-check-label" for="run_update_eve_models">{% translate "Update Eve Entirty Models" %}</label>
+                    <p class="figure-caption">Force updates to ALL Eve Entity Names</p>
                 </div>
-                <figcaption class="figure-caption">Force updates to ALL Eve Entity Names</figcaption>
             </div>
+
             <div class="card-footer">
                 <input type="submit" value="{% translate "Submit" %}" class="btn btn-primary w-100 mt-auto">
             </div>

--- a/corptools/templates/corptools/admin.html
+++ b/corptools/templates/corptools/admin.html
@@ -7,7 +7,9 @@
 {% endblock %}
 
 {% block content %}
-<h2 class="text-center">{% translate "Corptools Configuration Info" %}</h2>
+{% translate "Corptools Configuration Info" as page_title %}
+{% include "framework/header/page-header.html" with title=page_title %}
+
 <div class="d-flex flex-wrap" >
     <form action="{% url 'corptools:run_tasks' %}" method="post" class="card m-2 flex-grow-1">
         <!-- <div class="card m-2 flex-grow-1" style="min-width: 350px;"> -->

--- a/corptools/templates/corptools/admin.html
+++ b/corptools/templates/corptools/admin.html
@@ -547,7 +547,7 @@
                     <div class="input-group">
                         <span class='form-control' id="upload-file-info"></span>
                         <span class="input-group-btn">
-                            <label class="btn btn-default" for="file">
+                            <label class="btn btn-secondary" for="file">
                                 <input id="file" name="file" type="file" style="display:none" onchange="$('#upload-file-info').html(this.files[0].name)">
                                 {% translate "Browse" %}
                             </label>

--- a/corptools/templates/corptools/admin.html
+++ b/corptools/templates/corptools/admin.html
@@ -548,9 +548,9 @@
                                 <input id="file" name="file" type="file" style="display:none" onchange="$('#upload-file-info').html(this.files[0].name)">
                                 {% translate "Browse" %}
                             </label>
-                        </div>
-                        <small id="descriptionHelp" class="form-text text-muted">{% translate "PYFA XML Skills required list" %}.</small>
-
+                        </span>
+                    </div>
+                    <p id="descriptionHelp" class="form-text text-muted">{% translate "PYFA XML Skills required list" %}.</p>
                 </div>
             </div>
         </div>

--- a/corptools/templates/corptools/admin.html
+++ b/corptools/templates/corptools/admin.html
@@ -18,43 +18,43 @@
                 <hr>
                 {% csrf_token %}
                 <div class="form-check">
-                    <input type="checkbox" name="run_clear_etag" class="form-check-input" id="run_clear_etag" />
+                    <input type="checkbox" name="run_clear_etag" class="form-check-input" id="run_clear_etag">
                     <label class="form-check-label" for="run_clear_etag">{% translate "Clear all cached Etags" %}</label>
                 </div>
                 <figcaption class="figure-caption">Wipe all the etags from cache to force new data pulls</figcaption>
-                <br/>
+                <br>
                 <div class="form-check">
-                    <input type="checkbox" name="run_universe" class="form-check-input" id="run_universe" />
+                    <input type="checkbox" name="run_universe" class="form-check-input" id="run_universe">
                     <label class="form-check-label" for="run_universe">{% translate "Update EvE Map Data" %}</label>
                 </div>
                 <figcaption class="figure-caption">Force a full map update from ESI</figcaption>
-                <br/>
+                <br>
                 <div class="form-check">
-                    <input type="checkbox" name="run_locations" class="form-check-input" id="run_locations" />
+                    <input type="checkbox" name="run_locations" class="form-check-input" id="run_locations">
                     <label class="form-check-label" for="run_locations">{% translate "Force update all Citadel Locations" %}</label>
                 </div>
                 <figcaption class="figure-caption">Attempt to update all Citadel names from ESI</figcaption>
-                <br/>
+                <br>
                 <div class="form-check">
-                    <input type="checkbox" name="run_update_all" class="form-check-input" id="run_update_all" />
+                    <input type="checkbox" name="run_update_all" class="form-check-input" id="run_update_all">
                     <label class="form-check-label" for="run_update_all">{% translate "Force all character updates" %}</label>
                 </div>
                 <figcaption class="figure-caption">Force updates to ALL Character Audits</figcaption>
-                <br/>
+                <br>
                 <div class="form-check">
-                    <input type="checkbox" name="run_corp_updates" class="form-check-input" id="run_corp_updates" />
+                    <input type="checkbox" name="run_corp_updates" class="form-check-input" id="run_corp_updates">
                     <label class="form-check-label" for="run_corp_updates">{% translate "Force all corp updates" %}</label>
                 </div>
                 <figcaption class="figure-caption">Force updates to ALL Corporation Audits</figcaption>
-                <br/>
+                <br>
                 <div class="form-check">
-                    <input type="checkbox" name="run_update_eve_models" class="form-check-input" id="run_update_eve_models" />
+                    <input type="checkbox" name="run_update_eve_models" class="form-check-input" id="run_update_eve_models">
                     <label class="form-check-label" for="run_update_eve_models">{% translate "Update Eve Entirty Models" %}</label>
                 </div>
                 <figcaption class="figure-caption">Force updates to ALL Eve Entity Names</figcaption>
             </div>
             <div class="card-footer">
-                <input type="submit" value="{% translate "Submit" %}" class="btn btn-primary w-100 mt-auto" />
+                <input type="submit" value="{% translate "Submit" %}" class="btn btn-primary w-100 mt-auto">
             </div>
         <!-- </div> -->
     </form>
@@ -536,7 +536,7 @@
                 {% csrf_token %}
                 <div class="form-group">
                     <label for="name">{% translate "Skill List Description" %}</label>
-                    <input type="text" class="form-control" name="name" placeholder="Enter Description" />
+                    <input type="text" class="form-control" name="name" placeholder="Enter Description">
                     <small id="nameHelp" class="form-text text-muted">{% translate "This will show as the name of the Skill List" %}.</small>
                 </div>
                 <div class="form-group">
@@ -544,7 +544,7 @@
                         <span class='form-control' id="upload-file-info"></span>
                         <span class="input-group-btn">
                             <label class="btn btn-default" for="file">
-                                <input id="file" name="file" type="file" style="display:none" onchange="$('#upload-file-info').html(this.files[0].name)" />
+                                <input id="file" name="file" type="file" style="display:none" onchange="$('#upload-file-info').html(this.files[0].name)">
                                 {% translate "Browse" %}
                             </label>
                         </div>
@@ -554,7 +554,7 @@
             </div>
         </div>
         <div class="card-footer">
-            <input type="submit" class="btn w-100 btn-primary" />
+            <input type="submit" class="btn w-100 btn-primary">
         </div>
     </form>
 </div>


### PR DESCRIPTION
### Changed

- Make stuff translatable
- Use Bootstrap markup for forms
- Use framework page header template

### Fixed

- HTML5 is not (x)HTML
- `figcacption` is for images, videos and other embedded media
- Markup in Skill Lists box
- Page title (Supersedes #194)
- Browse button class