### PR TITLE
[ADD] Missing `hr`

### DIFF
--- a/corptools/templates/corptools/admin.html
+++ b/corptools/templates/corptools/admin.html
@@ -66,6 +66,7 @@
             <h5 class="card-title text-center">
                 {% translate "Corptools Module Configuration" %}
             </h5>
+            <hr>
             <div>
                 <table class="table">
                     <thead>


### PR DESCRIPTION
### Added

- Missing `hr` for "Corptools Module Configuration" panel header

#### Before

![image](https://github.com/user-attachments/assets/975f2515-c4df-4680-a58c-ccca77242129)


#### After

![image](https://github.com/user-attachments/assets/16bc7f8c-8fb5-4a39-ba23-e236526ffbb7)
