### PR TITLE
[FIX] ETag handling fixes

### DIFF
--- a/corptools/task_helpers/etag_helpers.py
+++ b/corptools/task_helpers/etag_helpers.py
@@ -59,10 +59,11 @@ def set_etag_header_openapi(
         operation,
         req
 ):
-    etag_key = get_etag_key(operation)
-    etag = req.headers.get('ETag', None)
-    if etag is not None:
-        result = cache.set(etag_key, etag, MAX_ETAG_LIFE)
+    etag = req.headers.get("ETag") if req else None
+    if etag:
+        result = cache.set(
+            key=get_etag_key(operation=operation), value=etag, timeout=MAX_ETAG_LIFE
+        )
         logger.debug(
             f"ETag: set_etag {operation} - etag:{etag} - stored:{result}")
 


### PR DESCRIPTION
### Fixed

- Force update in `openapi_etag_result`
- `single_page` when `result` is not a tuple

### Changed

- Simplify `set_etag_header_openapi`. Also fixes an issue when `req` is not a result, but an exception (as in line 268: `set_etag_header_openapi(operation, e)`)