### PR TITLE
Remove deprecated csrf parameter in api

### DIFF
--- a/corptools/api/__init__.py
+++ b/corptools/api/__init__.py
@@ -10,7 +10,7 @@ from . import character, core, corporation, extras
 logger = get_extension_logger(__name__)
 
 api = NinjaAPI(title="CorpTools API", version="0.0.1",
-               urls_namespace='corptools:new_api', auth=django_auth, csrf=True,
+               urls_namespace='corptools:new_api', auth=django_auth,
                openapi_url=settings.DEBUG and "/openapi.json" or "")
 
 # Add the core endpoints


### PR DESCRIPTION
django-ninja 1.5.0 breaks corptools due to vitalik/django-ninja#1524 . According to the docs (https://django-ninja.dev/reference/csrf/) csrf is on by default when using `auth=django_auth`, so removing the parameter doesn't change the behaviour.


Fixes Solar-Helix-Independent-Transport/allianceauth-corp-tools#247