### PR TITLE
Add missing variable before use in corp helper

### DIFF
--- a/corptools/task_helpers/corp_helpers.py
+++ b/corptools/task_helpers/corp_helpers.py
@@ -1288,6 +1288,7 @@ def fetch_coordiantes(self, corp_id):
         return f"CT: COORDS No Tokens or Assets for {_corporation.corporation.corporation_name}"
 
     _all_ids = assets.values_list("item_id", flat=True)
+    locations = []
 
     for id_chunk in providers.esi.chunk_ids(_all_ids):
         locations += providers.esi.client.Assets.post_corporations_corporation_id_assets_locations(


### PR DESCRIPTION
This pull request introduces a minor change to the `fetch_coordiantes` function in `corptools/task_helpers/corp_helpers.py`. The update adds an explicit initialization of the `locations` list before it is used to accumulate asset location data.

* Explicitly initializes the `locations` list at the start of the function to ensure correct accumulation of asset locations.