### PR TITLE
[REMOVE] `pydantic` as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ dependencies = [
     "django-model-utils",
     "django-ninja<2,>=1.0.1",
     "networkx",
-    "pydantic>=2.12.3,<3",    # model defaults issue
 ]
 optional-dependencies.test = [
     "allianceauth-securegroups",


### PR DESCRIPTION
Let `aiopenapi3` handle it through Django-ESI

Fixes #253 