### PR TITLE
fix: Fix update_models_from_sde import call in ct_setup.py

### DIFF
--- a/corptools/management/commands/ct_setup.py
+++ b/corptools/management/commands/ct_setup.py
@@ -5,7 +5,7 @@ from django.core.management.base import BaseCommand
 
 from allianceauth.crontab.utils import offset_cron
 
-from corptools.tasks import update_models_from_sde
+from eve_sde.tasks import update_models_from_sde
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
In last update there's error in ct_setup function. Execute fails because of wrong import of update_models_from_sde function.