### PR TITLE
feat: blueprint ME/TE/Runs on character & corporation assets

### DIFF
--- a/corptools/app_settings.py
+++ b/corptools/app_settings.py
@@ -164,6 +164,7 @@ def get_character_scopes():
         _scopes += [
             # Assets
             'esi-assets.read_assets.v1',
+            'esi-characters.read_blueprints.v1',
         ]
 
     if CT_CHAR_SKILLS_MODULE:
@@ -341,6 +342,7 @@ _corp_scopes_wallets = [
 # assets
 _corp_scopes_assets = [
     'esi-assets.read_corporation_assets.v1',
+    'esi-corporations.read_blueprints.v1',
 ]
 
 _corp_scopes_contracts = [

--- a/corptools/migrations/0006_bpc_me_te_runs.py
+++ b/corptools/migrations/0006_bpc_me_te_runs.py
@@ -1,0 +1,50 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("corptools", "0005_sovereigntyhub_sovereigntyhubreagent_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="characterasset",
+            name="material_efficiency",
+            field=models.SmallIntegerField(default=None, null=True),
+        ),
+        migrations.AddField(
+            model_name="characterasset",
+            name="time_efficiency",
+            field=models.SmallIntegerField(default=None, null=True),
+        ),
+        migrations.AddField(
+            model_name="characterasset",
+            name="runs",
+            field=models.IntegerField(default=None, null=True),
+        ),
+        migrations.AddField(
+            model_name="corpasset",
+            name="material_efficiency",
+            field=models.SmallIntegerField(default=None, null=True),
+        ),
+        migrations.AddField(
+            model_name="corpasset",
+            name="time_efficiency",
+            field=models.SmallIntegerField(default=None, null=True),
+        ),
+        migrations.AddField(
+            model_name="corpasset",
+            name="runs",
+            field=models.IntegerField(default=None, null=True),
+        ),
+        migrations.AddField(
+            model_name="corptoolsconfiguration",
+            name="disable_update_blueprints",
+            field=models.BooleanField(
+                blank=True,
+                default=False,
+                help_text="Temporarily disable the ESI pulls for Blueprint ME/TE/Runs Data",
+            ),
+        ),
+    ]

--- a/corptools/models/assets.py
+++ b/corptools/models/assets.py
@@ -42,6 +42,11 @@ class Asset(models.Model):
     # extra's
     name = models.CharField(max_length=255, null=True, default=None)
 
+    # blueprint attributes (from the blueprints endpoint, matched by item_id)
+    material_efficiency = models.SmallIntegerField(null=True, default=None)
+    time_efficiency = models.SmallIntegerField(null=True, default=None)
+    runs = models.IntegerField(null=True, default=None)
+
     class Meta:
         abstract = True
         indexes = [

--- a/corptools/models/audits.py
+++ b/corptools/models/audits.py
@@ -140,6 +140,11 @@ class CorptoolsConfiguration(SingletonModel):
         blank=True,
         help_text="Temporarily disable the ESI pulls for Character industry Job Data"
     )
+    disable_update_blueprints = models.BooleanField(
+        default=False,
+        blank=True,
+        help_text="Temporarily disable the ESI pulls for Blueprint ME/TE/Runs Data"
+    )
 
     class Meta:
         permissions = (

--- a/corptools/providers.py
+++ b/corptools/providers.py
@@ -140,6 +140,7 @@ esi_openapi = OpenAPI(
         "GetCharactersCharacterIdAssets",
         "PostCharactersCharacterIdAssetsNames",
         "PostCharactersCharacterIdAssetsLocations",
+        "GetCharactersCharacterIdBlueprints",
         # Character Location
         "GetCharactersCharacterIdShip",
         "GetCharactersCharacterIdLocation",
@@ -151,6 +152,7 @@ esi_openapi = OpenAPI(
         "GetCharactersCharacterIdContactsLabels",
         # Corporate Assets
         "GetCorporationsCorporationIdAssets",
+        "GetCorporationsCorporationIdBlueprints",
         "PostCorporationsCorporationIdAssetsNames",
         "PostCorporationsCorporationIdAssetsLocations",
         # Character Skills

--- a/corptools/task_helpers/char_tasks.py
+++ b/corptools/task_helpers/char_tasks.py
@@ -42,6 +42,7 @@ from ..models import (
     Contract,
     ContractItem,
     CorporationHistory,
+    CorptoolsConfiguration,
     EveLocation,
     EveName,
     Implant,
@@ -468,6 +469,11 @@ def update_character_assets(character_id, force_refresh=False):
             update_den_locations(character_id)
         except Exception as e:
             logger.error(e)
+        try:
+            # Enrich blueprint assets with ME/TE/Runs!
+            update_character_blueprints(character_id, force_refresh=force_refresh)
+        except Exception as e:
+            logger.error(e)
 
     except HTTPNotModified as e:
         _, _, tb = sys.exc_info()
@@ -527,6 +533,60 @@ def update_character_assets_names(character_id):
             if asset.item_id in id_list:
                 asset.name = id_list.get(asset.item_id)
                 asset.save()
+
+
+def update_character_blueprints(character_id, force_refresh=False):
+    """
+        Uses GetCharactersCharacterIdBlueprints to enrich stored assets with the
+        blueprint ME/TE/Runs, matched by item_id. The /assets/ endpoint does not
+        carry these, so they are pulled here and written onto the asset rows.
+    """
+    if CorptoolsConfiguration.get_solo().disable_update_blueprints:
+        return "Disabled"
+
+    audit_char = CharacterAudit.objects.get(
+        character__character_id=character_id
+    )
+
+    logger.debug(
+        f"Updating Blueprints for: {audit_char.character.character_name}")
+
+    req_scopes = ['esi-characters.read_blueprints.v1']
+
+    token = get_token(character_id, req_scopes)
+
+    if not token:
+        return "No Tokens"
+
+    blueprints = providers.esi_openapi.client.Character.GetCharactersCharacterIdBlueprints(
+        character_id=character_id,
+        token=token
+    ).results(
+        force_refresh=force_refresh,
+        # the asset rows are recreated on every asset pull, so an unchanged
+        # blueprint list must still be applied to the fresh rows.
+        use_etag=False,
+        store_cache=False
+    )
+
+    bp_map = {b.item_id: b for b in blueprints}
+
+    updates = []
+    for id_chunk in providers.esi_openapi.chunk_ids(list(bp_map.keys())):
+        for asset in CharacterAsset.objects.filter(
+            character=audit_char, item_id__in=id_chunk
+        ):
+            bp = bp_map[asset.item_id]
+            asset.material_efficiency = bp.material_efficiency
+            asset.time_efficiency = bp.time_efficiency
+            asset.runs = bp.runs
+            updates.append(asset)
+
+    CharacterAsset.objects.bulk_update(
+        updates,
+        ["material_efficiency", "time_efficiency", "runs"],
+        batch_size=CT_DB_BULK_CREATE_BATCH_SIZE
+    )
 
 
 def update_den_locations(character_id, force_refresh=False):

--- a/corptools/tasks/corporation/assets.py
+++ b/corptools/tasks/corporation/assets.py
@@ -22,6 +22,7 @@ from corptools.models import (
     BridgeOzoneLevel,
     CorpAsset,
     CorporationAudit,
+    CorptoolsConfiguration,
     EveLocation,
     Structure,
 )
@@ -117,6 +118,10 @@ def corp_update_assets(corp_id, force_refresh: bool = False):
         corp_update_asset_names(corp_id)
     except Exception as e:
         logger.error(e)
+    try:
+        update_corporation_blueprints(corp_id, force_refresh=force_refresh)
+    except Exception as e:
+        logger.error(e)
 
     que = []
     que.append(fetch_coordiantes.si(corp_id, force_refresh=force_refresh))
@@ -126,6 +131,60 @@ def corp_update_assets(corp_id, force_refresh: bool = False):
     chain(que).apply_async(priority=7)
 
     return f"Finished assets for: {audit_corp.corporation}"
+
+
+def update_corporation_blueprints(corp_id, force_refresh: bool = False):
+    """
+        Uses GetCorporationsCorporationIdBlueprints to enrich stored corp assets
+        with the blueprint ME/TE/Runs, matched by item_id. Requires the Director
+        role and the read_blueprints corp scope.
+    """
+    if CorptoolsConfiguration.get_solo().disable_update_blueprints:
+        return "Disabled"
+
+    audit_corp = CorporationAudit.objects.get(
+        corporation__corporation_id=corp_id)
+    logger.debug("Updating Blueprints for: {}".format(
+        audit_corp.corporation))
+
+    req_scopes = ['esi-corporations.read_blueprints.v1',
+                  'esi-characters.read_corporation_roles.v1']
+    req_roles = ['Director']
+
+    token = get_corp_token(corp_id, req_scopes, req_roles)
+
+    if not token:
+        return "No Tokens"
+
+    blueprints = providers.esi_openapi.client.Corporation.GetCorporationsCorporationIdBlueprints(
+        corporation_id=corp_id,
+        token=token
+    ).results(
+        force_refresh=force_refresh,
+        # the asset rows are recreated on every asset pull, so an unchanged
+        # blueprint list must still be applied to the fresh rows.
+        use_etag=False,
+        store_cache=False
+    )
+
+    bp_map = {b.item_id: b for b in blueprints}
+
+    updates = []
+    for id_chunk in providers.esi_openapi.chunk_ids(list(bp_map.keys())):
+        for asset in CorpAsset.objects.filter(
+            corporation=audit_corp, item_id__in=id_chunk
+        ):
+            bp = bp_map[asset.item_id]
+            asset.material_efficiency = bp.material_efficiency
+            asset.time_efficiency = bp.time_efficiency
+            asset.runs = bp.runs
+            updates.append(asset)
+
+    CorpAsset.objects.bulk_update(
+        updates,
+        ["material_efficiency", "time_efficiency", "runs"],
+        batch_size=CT_DB_BULK_CREATE_BATCH_SIZE
+    )
 
 
 @shared_task(bind=True)

--- a/corptools/tests/test_blueprint_enrichment.py
+++ b/corptools/tests/test_blueprint_enrichment.py
@@ -1,0 +1,129 @@
+# Standard Library
+from unittest.mock import MagicMock, patch
+
+# AA Example App
+from corptools.models import (
+    CharacterAsset,
+    CharacterAudit,
+    CorpAsset,
+    CorptoolsConfiguration,
+)
+from corptools.task_helpers.char_tasks import update_character_blueprints
+from corptools.tasks.corporation.assets import update_corporation_blueprints
+
+from . import CorptoolsTestCase
+
+
+def _bp(item_id, me=10, te=20, runs=50):
+    bp = MagicMock()
+    bp.item_id = item_id
+    bp.material_efficiency = me
+    bp.time_efficiency = te
+    bp.runs = runs
+    return bp
+
+
+def _mock_providers(mock_providers, blueprints, tag="Character",
+                    operation="GetCharactersCharacterIdBlueprints"):
+    op = getattr(getattr(mock_providers.esi_openapi.client, tag), operation)
+    op.return_value.results.return_value = blueprints
+    # chunk_ids is used to batch the asset update; keep it a real chunker.
+    mock_providers.esi_openapi.chunk_ids.side_effect = \
+        lambda lo, n=750: [lo[i:i + n] for i in range(0, len(lo), n)]
+
+
+class TestCharacterBlueprintEnrichment(CorptoolsTestCase):
+    def setUp(self):
+        super().setUp()
+        self.audit, _ = CharacterAudit.objects.get_or_create(
+            character=self.char1)
+        self.asset = CharacterAsset.objects.create(
+            character=self.audit,
+            type_id=999,
+            item_id=5001,
+            location_id=60003760,
+            location_flag="Hangar",
+            location_type="station",
+            quantity=1,
+            singleton=True,
+            blueprint_copy=True,
+        )
+
+    @patch("corptools.task_helpers.char_tasks.get_token")
+    def test_disabled_via_config_skips_pull(self, mock_get_token):
+        config = CorptoolsConfiguration.get_solo()
+        config.disable_update_blueprints = True
+        config.save()
+
+        result = update_character_blueprints(self.char1.character_id)
+
+        self.assertEqual(result, "Disabled")
+        mock_get_token.assert_not_called()
+
+    @patch("corptools.task_helpers.char_tasks.get_token")
+    def test_no_token_returns_early(self, mock_get_token):
+        mock_get_token.return_value = False
+
+        result = update_character_blueprints(self.char1.character_id)
+
+        self.assertEqual(result, "No Tokens")
+        self.asset.refresh_from_db()
+        self.assertIsNone(self.asset.material_efficiency)
+
+    @patch("corptools.task_helpers.char_tasks.providers")
+    @patch("corptools.task_helpers.char_tasks.get_token")
+    def test_enriches_assets_by_item_id(self, mock_get_token, mock_providers):
+        mock_get_token.return_value = MagicMock()
+        _mock_providers(
+            mock_providers, [_bp(5001), _bp(4040)])  # 4040: no matching asset
+
+        update_character_blueprints(self.char1.character_id)
+
+        self.asset.refresh_from_db()
+        self.assertEqual(self.asset.material_efficiency, 10)
+        self.assertEqual(self.asset.time_efficiency, 20)
+        self.assertEqual(self.asset.runs, 50)
+
+
+class TestCorporationBlueprintEnrichment(CorptoolsTestCase):
+    def setUp(self):
+        super().setUp()
+        self.asset = CorpAsset.objects.create(
+            corporation=self.cp1,
+            type_id=999,
+            item_id=6001,
+            location_id=60003760,
+            location_flag="CorpSAG1",
+            location_type="station",
+            quantity=1,
+            singleton=True,
+            blueprint_copy=True,
+        )
+
+    @patch("corptools.tasks.corporation.assets.get_corp_token")
+    def test_disabled_via_config_skips_pull(self, mock_get_corp_token):
+        config = CorptoolsConfiguration.get_solo()
+        config.disable_update_blueprints = True
+        config.save()
+
+        result = update_corporation_blueprints(
+            self.corp1.corporation_id)
+
+        self.assertEqual(result, "Disabled")
+        mock_get_corp_token.assert_not_called()
+
+    @patch("corptools.tasks.corporation.assets.providers")
+    @patch("corptools.tasks.corporation.assets.get_corp_token")
+    def test_enriches_assets_by_item_id(self, mock_get_corp_token,
+                                        mock_providers):
+        mock_get_corp_token.return_value = MagicMock()
+        _mock_providers(
+            mock_providers, [_bp(6001, me=5, te=10, runs=-1)],
+            tag="Corporation", operation="GetCorporationsCorporationIdBlueprints")
+
+        update_corporation_blueprints(self.corp1.corporation_id)
+
+        self.asset.refresh_from_db()
+        self.assertEqual(self.asset.material_efficiency, 5)
+        self.assertEqual(self.asset.time_efficiency, 10)
+        self.assertEqual(self.asset.runs, -1)

--- a/corptools/views.py
+++ b/corptools/views.py
@@ -80,6 +80,7 @@ CORP_REQUIRED_SCOPES = [
 
     # Assets
     'esi-assets.read_corporation_assets.v1',
+    'esi-corporations.read_blueprints.v1',
 
     # All...
     'esi-search.search_structures.v1',


### PR DESCRIPTION
The /assets/ ESI endpoint reports whether an item is a blueprint copy but not its material efficiency, time efficiency or runs. Pull those from the /blueprints/ endpoint and enrich the stored asset rows (matched by item_id), for both character and corporation assets.
- Add nullable material_efficiency / time_efficiency / runs to the Asset base (inherited by CharacterAsset and CorpAsset).
- Add update_character_blueprints / update_corporation_blueprints enrichment passes, run after the asset bulk_create (mirroring the asset-names pass). Use use_etag=False so an unchanged blueprint list is still re-applied to the freshly recreated asset rows; chunk the id lookup for large blueprint sets.
- Register the two blueprint operations (already present in the bundled spec) and add the read_blueprints scopes to the character and corp scope sets.
- Gate behind a disable_update_blueprints config toggle; the pass no-ops when the read_blueprints scope is absent, so it is safe on installs that have not re-authed.