### PR TITLE
fix(bridges): coalesce null ozone to 0 in get_dashboard_gates

### DIFF
--- a/corptools/api/corporation/dashboards.py
+++ b/corptools/api/corporation/dashboards.py
@@ -86,7 +86,7 @@ class DashboardApiEndpoints:
                     output[to_sys]["end"] = {
                         "system_name": s.system_name.name,
                         "system_id": s.system_name_id,
-                        "ozone": levels.get(s.structure_id),
+                        "ozone": levels.get(s.structure_id) or 0,
                         "known": True,
                         "active": active,
                         "expires": days,
@@ -97,7 +97,7 @@ class DashboardApiEndpoints:
                     output[from_sys]["start"] = {
                         "system_name": s.system_name.name,
                         "system_id": s.system_name_id,
-                        "ozone": levels.get(s.structure_id),
+                        "ozone": levels.get(s.structure_id) or 0,
                         "known": True,
                         "active": active,
                         "expires": days,


### PR DESCRIPTION
## Fix: bridges audit page crashes on `null` ozone

 The bridges audit page (`/audit/r/corp/bridges`) currently crashes with:

 ```
 TypeError: Cannot read properties of null (reading 'toLocaleString')
 ```

 ### Root cause

 `get_dashboard_gates` builds `levels` from `CorpAsset` rows with `type_id=16273` (Liquid Ozone) and `location_flag="StructureFuel"`. For jump bridges that have no LO in their fuel bay, `levels.get(s.structure_id)` returns `None`, which is then returned to the frontend as `ozone: null`.

 The React frontend renders this with `ozone.toLocaleString()`, which throws on `null` and takes down the entire bridges page.

 ### Fix

 Coalesce `None` → `0` on both the `start` and `end` bridge dicts:

 ```python
 "ozone": levels.get(s.structure_id) or 0,
 ```

 The `known: False` branch already only emits `{known, active}`, and the frontend already guards `n.start.known && i.push(n.start.ozone)` — so the only unguarded case is `known: True` with `ozone: None`, which this patch closes.

 ### Repro

 Have a jump bridge structure (type_id 35841) with no Liquid Ozone in its `StructureFuel` bay, then open `/audit/r/corp/bridges`.