### PR TITLE
Wrap asset flush+recreate in a transaction to prevent transient empty

### DIFF
--- a/corptools/task_helpers/char_tasks.py
+++ b/corptools/task_helpers/char_tasks.py
@@ -8,6 +8,7 @@ from celery import shared_task
 from eve_sde.models import ItemType, Planet
 
 # Django
+from django.db import transaction
 from django.db.models import F
 from django.db.models.functions import Power, Sqrt
 from django.utils import timezone
@@ -455,10 +456,14 @@ def update_character_assets(character_id, force_refresh=False):
                 items.append(ship)
 
         # We now have some FKeys so slow it down...
-        CharacterAsset.objects.filter(character=audit_char).delete()
+        # Flush + recreate in one transaction so concurrent readers never see
+        # the character with zero assets mid-refresh (e.g. securegroups asset
+        # filters false-failing during the update window).
+        with transaction.atomic():
+            CharacterAsset.objects.filter(character=audit_char).delete()
 
-        CharacterAsset.objects.bulk_create(
-            items, batch_size=CT_DB_BULK_CREATE_BATCH_SIZE)
+            CharacterAsset.objects.bulk_create(
+                items, batch_size=CT_DB_BULK_CREATE_BATCH_SIZE)
 
         logger.debug(
             f"CT_TIME: {time.perf_counter() - _st} update_character_assets {character_id}"

--- a/corptools/tasks/corporation/assets.py
+++ b/corptools/tasks/corporation/assets.py
@@ -8,6 +8,7 @@ from celery import chain, shared_task
 from eve_sde.models import ItemType
 
 # Django
+from django.db import transaction
 from django.db.models import F, Q
 from django.db.models.aggregates import Sum
 
@@ -89,12 +90,16 @@ def corp_update_assets(corp_id, force_refresh: bool = False):
 
     delete_query = CorpAsset.objects.filter(
         corporation=audit_corp)  # Flush Assets
-    if delete_query.exists():
-        # with coords we need to care about the fkeys/signals
-        delete_query.delete()
+    # Flush + recreate in one transaction so concurrent readers never see the
+    # corporation with zero assets mid-refresh (e.g. securegroups asset filters
+    # false-failing during the update window).
+    with transaction.atomic():
+        if delete_query.exists():
+            # with coords we need to care about the fkeys/signals
+            delete_query.delete()
 
-    CorpAsset.objects.bulk_create(
-        items, batch_size=CT_DB_BULK_CREATE_BATCH_SIZE)
+        CorpAsset.objects.bulk_create(
+            items, batch_size=CT_DB_BULK_CREATE_BATCH_SIZE)
     try:
         corp_update_asset_names(corp_id)
     except Exception as e:


### PR DESCRIPTION
update_character_assets and corp_update_assets delete all of a character's/corporation's assets and then bulk_create the fresh set as two separate, auto-committed statements. Between the delete and the (batched) bulk_create, the character/corp momentarily has zero assets in the DB.

Any consumer reading assets concurrently can observe this empty window. In particular the securegroups AssetsFilter (count() > 0) intermittently false-fails "has X asset anywhere" checks, sending spurious pending-removal notifications to members whose assets never actually moved. Larger asset lists widen the window and make collisions more likely.

Wrap the delete + bulk_create in transaction.atomic() so concurrent readers see either the old set or the new set, never zero. This also prevents an exception between the delete and bulk_create from leaving assets deleted until the next successful refresh.